### PR TITLE
Skip convertPointToView test on iOS for now

### DIFF
--- a/Resources/ti.ui.view.test.js
+++ b/Resources/ti.ui.view.test.js
@@ -518,7 +518,8 @@ describe('Titanium.UI.View', function () {
 	});
 
 	// FIXME Android reports 223 for one of the values we expect 123 (result.y?)
-	(utilities.isAndroid() ? it.skip : it)('convertPointToView', function (finish) {
+	// FIXME iOS sometimes returns null for the converted point. Timeout issue? 
+	((utilities.isAndroid() || utilities.isIOS()) ? it.skip : it)('convertPointToView', function (finish) {
 		win = Ti.UI.createWindow();
 		var a = Ti.UI.createView({backgroundColor:'red'}),
 			b = Ti.UI.createView({ top: '100', backgroundColor: 'blue' }),


### PR DESCRIPTION
@sgtcoolguy to review.

This test is responsible for ongoing Jenkins failures causing other tests of that suite to fail as well:
```
12:38:25   1) convertPointToView
12:38:25     {"state":"failed","duration":4,"suite":"Titanium.UI.View","title":"convertPointToView","error":{"name":"AssertionError","actual":null,"operator":"to be an object","message":"expected null to be an object","generatedMessage":true,"stack":"file:///var/lib/jenkins/Library/Developer/CoreSimulator/Devices/56A0E9B9-57A6-47B5-A367-B29552084662/data/Containers/Bundle/Application/4BCA0CF5-0D0C-46B6-9C5D-85A09333ABEB/mocha.app/should.js:1411:20\nfile:///var/lib/jenkins/Library/Developer/CoreSimulator/Devices/56A0E9B9-57A6-47B5-A367-B29552084662/data/Containers/Bundle/Application/4BCA0CF5-0D0C-46B6-9C5D-85A09333ABEB/mocha.app/ti.ui.view.test.js:537:25","line":1492,"column":14,"sourceURL":"file:///var/lib/jenkins/Library/Developer/CoreSimulator/Devices/56A0E9B9-57A6-47B5-A367-B29552084662/data/Containers/Bundle/Application/4BCA0CF5-0D0C-46B6-9C5D-85A09333ABEB/mocha.app/should.js"},"stdout":"[INFO] : \b\b \b Got postlayout event\n","stderr":""}
12:38:25   2) animate (height %)
12:38:25     {"state":"failed","duration":5010,"suite":"Titanium.UI.View","title":"animate (height %)","error":{"message":"timeout of 5000ms exceeded","stack":"file:///var/lib/jenkins/Library/Developer/CoreSimulator/Devices/56A0E9B9-57A6-47B5-A367-B29552084662/data/Containers/Bundle/Application/4BCA0CF5-0D0C-46B6-9C5D-85A09333ABEB/mocha.app/ti-mocha.js:4334:23"},"stdout":"","stderr":""}
12:38:25   3) animate (width %)
12:38:25     {"state":"failed","duration":5008,"suite":"Titanium.UI.View","title":"animate (width %)","error":{"message":"timeout of 5000ms exceeded","stack":"file:///var/lib/jenkins/Library/Developer/CoreSimulator/Devices/56A0E9B9-57A6-47B5-A367-B29552084662/data/Containers/Bundle/Application/4BCA0CF5-0D0C-46B6-9C5D-85A09333ABEB/mocha.app/ti-mocha.js:4334:23"},"stdout":"","stderr":""}
12:38:25   4) animate (top %)
12:38:25     {"state":"failed","duration":5002,"suite":"Titanium.UI.View","title":"animate (top %)","error":{"message":"timeout of 5000ms exceeded","stack":"file:///var/lib/jenkins/Library/Developer/CoreSimulator/Devices/56A0E9B9-57A6-47B5-A367-B29552084662/data/Containers/Bundle/Application/4BCA0CF5-0D0C-46B6-9C5D-85A09333ABEB/mocha.app/ti-mocha.js:4334:23"},"stdout":"","stderr":""}
12:38:25   5) animate (left %)
12:38:25     {"state":"failed","duration":5009,"suite":"Titanium.UI.View","title":"animate (left %)","error":{"message":"timeout of 5000ms exceeded","stack":"file:///var/lib/jenkins/Library/Developer/CoreSimulator/Devices/56A0E9B9-57A6-47B5-A367-B29552084662/data/Containers/Bundle/Application/4BCA0CF5-0D0C-46B6-9C5D-85A09333ABEB/mocha.app/ti-mocha.js:4334:23"},"stdout":"","stderr":""}
...
12:38:25 945 Total Tests: 662 passed, 5 failed, 278 skipped.

```