### PR TITLE
Skip Ti.UI.WebView.loading test on Android for now

### DIFF
--- a/Resources/ti.ui.webview.test.js
+++ b/Resources/ti.ui.webview.test.js
@@ -26,7 +26,7 @@ describe('Titanium.UI.WebView', function () {
 		win = null;
 	});
 
-	it('loading', function (finish) {
+	(utilities.isAndroid() ? it.skip : it)('loading', function (finish) {
 		this.slow(5000);
 		this.timeout(10000);
 


### PR DESCRIPTION
Jenkins seems to fail because of my recent unit-test for iOS, because `Ti.UI.WebView.loading` is undefined on Android and it looks like Android doesn't even support the property. So two follow-up's:

1. What's about Windows, does it support the property?
2. We should update the docs in [here](https://github.com/appcelerator/titanium_mobile/blob/master/apidoc/Titanium/UI/WebView.yml#L538)

Thx! 🚀