### PR TITLE
Increase ti.ui.window.test.js 'close event is fired' timeout

### DIFF
--- a/Resources/ti.ui.window.test.js
+++ b/Resources/ti.ui.window.test.js
@@ -192,7 +192,7 @@ describe('Titanium.UI.Window', function () {
 		win.addEventListener('open', function () {
 			setTimeout(function () {
 				win.close();
-			}, 100);
+			}, 500);
 		});
 		win.open();
 	});


### PR DESCRIPTION
- Attempt to fix `close event is fired` by increasing the timeout before `close()` is called