### PR TITLE
Pull titanium from npm

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -25,7 +25,7 @@
     "commander": "*",
     "ejs": "~2.2.4",
     "stream-splitter": "~0.3.2",
-    "titanium": "git+http://github.com/appcelerator/titanium.git#master",
+    "titanium": "*",
     "wrench": "~1.5.4"
   },
   "engines": {


### PR DESCRIPTION
Looks like there has been some problems in the last few build on running npm install and grabbing titanium from git, * should give us similar (although changes that are made without bumping the version wont be gotten)

https://jenkins.appcelerator.org/blue/organizations/jenkins/titanium-sdk%2Ftitanium_mobile/detail/master/450/pipeline/94