### PR TITLE
[TIMOB-25094][TIMOB-25095] Fix for Ti.Media apiName tests

### DIFF
--- a/Resources/ti.media.audioplayer.test.js
+++ b/Resources/ti.media.audioplayer.test.js
@@ -11,7 +11,7 @@ var should = require('./utilities/assertions'),
 (utilities.isIOS() ? describe.skip : describe)('Titanium.Media.AudioPlayer', function () {
 	it.skip('apiName', function () { // FIXME This only works on an instance of a proxy now
 		should(Ti.Media.AudioPlayer).have.readOnlyProperty('apiName').which.is.a.String;
-		should(Ti.Media.AudioPlayer.apiName).be.eql('Titanium.Media.AudioPlayer');
+		should(Ti.Media.AudioPlayer.apiName).be.eql('Ti.Media.AudioPlayer');
 	});
 
 	it('STATE_BUFFERING', function () {

--- a/Resources/ti.media.sound.test.js
+++ b/Resources/ti.media.sound.test.js
@@ -11,7 +11,7 @@ var should = require('./utilities/assertions'),
 (utilities.isIOS() ? describe.skip : describe)('Titanium.Media.Sound', function () {
 	it.skip('apiName', function () { // FIXME This only works on an instance of a proxy now
 		should(Ti.Media.Sound).have.readOnlyProperty('apiName').which.is.a.String;
-		should(Ti.Media.Sound.apiName).be.eql('Titanium.Media.Sound');
+		should(Ti.Media.Sound.apiName).be.eql('Ti.Media.Sound');
 	});
 
 	it('STATE_BUFFERING', function () {


### PR DESCRIPTION
 [TIMOB-25094](https://jira.appcelerator.org/browse/TIMOB-25094) and [TIMOB-25095](https://jira.appcelerator.org/browse/TIMOB-25095)

`Ti.Media.Sound` and `Ti.Media.AudioPlayer` should be asserting with the Ti namepsace for `apiName`.