### PR TITLE
Autograb files

### DIFF
--- a/Resources/app.js
+++ b/Resources/app.js
@@ -97,6 +97,27 @@ require('./ti.ui.window.test');
 require('./ti.ui.windows.commandbar.test');
 require('./ti.utils.test');
 require('./ti.xml.test');
+
+// Load in any of the files added to the test/Resources folder of the SDK repos
+
+loadAddonTestFiles(Ti.Filesystem.resourcesDirectory);
+
+function loadAddonTestFiles (name) {
+	var info = Ti.Filesystem.getFile(name);
+	if (info && info.isDirectory()) {
+		info.getDirectoryListing().forEach(function (listing) {
+			loadAddonTestFiles(listing);
+		});
+	// Only load the test files
+	} else if (/\w+.addontest\.js$/i.test(info.name)) {
+		try {
+			require(name.replace(/.js/, '')); // eslint-disable-line security/detect-non-literal-require
+		} catch (e) {
+			console.log(e);
+		}
+	}
+}
+
 // ============================================================================
 
 // add a special mocha reporter that will time each test run using

--- a/Resources/app.js
+++ b/Resources/app.js
@@ -111,7 +111,7 @@ function loadAddonTestFiles (name) {
 	// Only load the test files
 	} else if (/\w+.addontest\.js$/i.test(info.name)) {
 		try {
-			require(name.replace(/.js/, '')); // eslint-disable-line security/detect-non-literal-require
+			require(name.replace(/.js$/, '')); // eslint-disable-line security/detect-non-literal-require
 		} catch (e) {
 			console.log(e);
 		}


### PR DESCRIPTION
Documentation update in appcelerator/titanium_mobile/pull/9511

This PR allows new test files to be added into titanium_mobile or titanium_mobile_windows without the need to copy over the app.js files.

I initially had it as JS files placed under a directory but realised that this made the migration of tests from an SDK repo to here slightly more effort than it should be (replacing `../utilities/assertion` -> `./utilities/assertion`).

It also now cleans up the modules/plugins dirs before and after a run in Jenkins