### PR TITLE
Increase TIMOB-20598 timeout

### DIFF
--- a/Resources/ti.ui.view.test.js
+++ b/Resources/ti.ui.view.test.js
@@ -352,6 +352,7 @@ describe('Titanium.UI.View', function () {
 	// FIXME: Android view.rect.y is not the same as view.top
 	// FIXME: iOS fails with 'New layout set while view [object TiUIView] animating'
 	it.androidAndIosBroken('TIMOB-20598', function (finish) {
+		this.timeout(10000);
 		var view = Ti.UI.createView({
 				backgroundColor:'red',
 				width: 100, height: 100,


### PR DESCRIPTION
Currently TIMOB-20598 is [failing for Windows](https://jenkins.appcelerator.org/blue/organizations/jenkins/titanium-sdk%2Ftitanium_mobile_windows/detail/PR-1153/1/tests), it seems it is because timeout is too short. I tested it locally and it needs at least 6.5 sec, but the default timeout is 5 sec. Increasing it to 10 sec.