### PR TITLE
Windows: Wait for some time before TextField.focus

### DIFF
--- a/Resources/ti.ui.textfield.test.js
+++ b/Resources/ti.ui.textfield.test.js
@@ -283,7 +283,9 @@ describe('Titanium.UI.TextField', function () {
 
 		// Start the test when the window has been opened.
 		win.addEventListener('open', function () {
-			textField.focus();
+			setTimeout(function () {
+				textField.focus();
+			}, 10);
 		});
 		win.open();
 	});


### PR DESCRIPTION
`focus-blur` in `ti.ui.textfield.test.js` [has been failing for Windows](https://jenkins.appcelerator.org/blue/organizations/jenkins/titanium-sdk%2Ftitanium_mobile_windows/detail/master/230/tests).
As far as I tested, Windows needs some interval before `focus` at `open`.
