### PR TITLE
Skip window_navigation on Windows Desktop

### DIFF
--- a/Resources/ti.ui.window.test.js
+++ b/Resources/ti.ui.window.test.js
@@ -422,8 +422,8 @@ describe('Titanium.UI.Window', function () {
 		win.open();
 	});
 
-	// Times out on Android
-	it.androidBroken('window_navigation', function (finish) {
+	// Times out on Android and Windows Desktop
+	it.androidAndWindowsDesktopBroken('window_navigation', function (finish) {
 		var rootWindowFocus = 0;
 		var rootWindowBlur = 0;
 		var rootWindowOpen = 0;


### PR DESCRIPTION
`window_navigation` test times out on Windows Desktop recently, that blocks current current builds.