### PR TITLE
Ensure a failed titanium build is reflected through to the script

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -274,6 +274,12 @@ function handleBuild(prc, next) {
 		console.log(data.toString().trim());
 		stderr += data.toString().trim() + '\n';
 	});
+
+	prc.on('close', (code) => {
+		if (code) {
+			return next(code);
+		}
+	})
 }
 
 function massageJSONString(testResults) {


### PR DESCRIPTION
This (hopefully) makes it so that when the Titanium build fails, the exit code will bubble through the node script so that it's more obvious where the failure was