### PR TITLE
[TIMOB-25760] HttpClient.location should point to redirected location

### DIFF
--- a/Resources/ti.network.httpclient.test.js
+++ b/Resources/ti.network.httpclient.test.js
@@ -511,4 +511,29 @@ describe('Titanium.Network.HTTPClient', function () {
 
 		xhr.send(form);
 	});
+
+	// HttpClient.location should point to redirected location
+	it('TIMOB-25760', function (finish) {
+		var xhr = Ti.Network.createHTTPClient(),
+			attempts = 3;
+		xhr.setTimeout(6e4);
+
+		xhr.onload = function () {
+			should(xhr.location).be.eql('https://www.appcelerator.com/');
+			finish();
+		};
+		xhr.onerror = function (e) {
+			if (attempts-- > 0) {
+				Ti.API.warn('failed, attempting to retry request...');
+				xhr.send();
+			} else {
+				Ti.API.debug(JSON.stringify(e, null, 2));
+				finish(new Error('failed to retrieve redirected content: ' + e));
+			}
+		};
+
+		xhr.open('GET', 'http://www.httpbin.org/redirect-to?url=https%3A%2F%2Fappcelerator.com/');
+		xhr.send();
+	});
+
 });


### PR DESCRIPTION
Add `Ti.Network.HttpClient` test for redirected URL. 
`HttpClient.location` should point to redirected location.
This works with iOS and Android. For Windows: [TIMOB-25760](https://jira.appcelerator.org/browse/TIMOB-25760)