### PR TITLE
create/deleteFile should not use resource directory

### DIFF
--- a/Resources/ti.filesystem.file.test.js
+++ b/Resources/ti.filesystem.file.test.js
@@ -208,11 +208,11 @@ describe('Titanium.Filesystem.File', function () {
 		should(dir.exists()).be.false;
 	});
 
-	it.windowsBroken('#createFile() and #deleteFile()', function () {
-		var newFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'myfile');
+	it('#createFile() and #deleteFile()', function () {
+		var newFile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'myfile');
 		should(newFile.exists()).be.false;
 		newFile.createFile();
-		should(newFile.exists()).be.true; // windows returns false here. Probably an async timing issue?
+		should(newFile.exists()).be.true;
 		newFile.deleteFile();
 		should(newFile.exists()).be.false;
 	});


### PR DESCRIPTION
`Ti.Filesystem` #createFile() and #deleteFile() test should not use `Ti.Filesystem.resourcesDirectory` because resource directory is read-only (but on iOS/Android it's not, according to the test result!?). We should use `applicationDataDirectory` instead in this case.