### PR TITLE
[TIMOB-25788] Re-enable windowsBroken HttpClient tests

### DIFF
--- a/Resources/ti.network.httpclient.test.js
+++ b/Resources/ti.network.httpclient.test.js
@@ -20,7 +20,7 @@ describe('Titanium.Network.HTTPClient', function () {
 	});
 
 	// FIXME iOS gives us an ELEMENT_NODE, not DOCUMENT_NODE
-	it.iosAndWindowsBroken('responseXML', function (finish) {
+	it.iosBroken('responseXML', function (finish) {
 		var xhr = Ti.Network.createHTTPClient(),
 			attempts = 3;
 		xhr.setTimeout(6e4);
@@ -179,7 +179,7 @@ describe('Titanium.Network.HTTPClient', function () {
 
 	// https://appcelerator.lighthouseapp.com/projects/32238/tickets/2339
 	// Timing out on Windows Phone
-	it.windowsBroken('responseHeadersBug', function (finish) {
+	it('responseHeadersBug', function (finish) {
 		var xhr = Ti.Network.createHTTPClient(),
 			attempts = 3;
 		xhr.setTimeout(3e4);


### PR DESCRIPTION
Re-enable `windowsBroken` HttpClient tests based on the result from https://github.com/appcelerator/titanium_mobile_windows/pull/1188
