### PR TITLE
[TIMOB-23332] Skip Contact.Person tests that prompts permission request

### DIFF
--- a/Resources/ti.contacts.person.test.js
+++ b/Resources/ti.contacts.person.test.js
@@ -11,8 +11,8 @@
 var should = require('./utilities/assertions');
 
 // FIXME Every test here fails on Android, likely due to permissions
-// FIXME This holds for permission prompt on iOS and hangs the tests. How can we "click OK" for user?
-describe.androidAndIosBroken('Titanium.Contacts.Person', function () {
+// FIXME This holds for permission prompt on iOS & Windows and hangs the tests. How can we "click OK" for user?
+describe.allBroken('Titanium.Contacts.Person', function () {
 
 	it('apiName', function () {
 		should(Ti.Contacts.Person).have.a.readOnlyProperty('apiName').which.is.a.String;


### PR DESCRIPTION
JIRA ticket: [TIMOB-23332](https://jira.appcelerator.org/browse/TIMOB-23332)

Relates to #42 . Tests against `Contacts.Person` on Windows actually requires permission request and it could hangs the app just like other platforms.
