### PR TITLE
Remove windowsBroken from maxLines test

### DIFF
--- a/Resources/ti.ui.label.test.js
+++ b/Resources/ti.ui.label.test.js
@@ -34,8 +34,7 @@ describe('Titanium.UI.Label', function () {
 		should(label.apiName).be.eql('Ti.UI.Label');
 	});
 
-	// FIXME Windows is missing accessor function
-	it.windowsBroken('maxLines', function () {
+	it('maxLines', function () {
 		var label = Ti.UI.createLabel({
 			text: 'This is a label with propably more than three lines of text. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog.',
 			maxLines: 2


### PR DESCRIPTION
Windows `ti.ui.label` `maxLines` failure should be addressed by [TIMOB-25648](https://jira.appcelerator.org/browse/TIMOB-25648).
