### PR TITLE
Skip failing tests for Windows

### DIFF
--- a/Resources/ti.network.test.js
+++ b/Resources/ti.network.test.js
@@ -78,7 +78,7 @@ describe('Titanium.Network', function () {
 	});
 
 	// Methods
-	it.windowsPhone81Broken('encodeURIComponent()', function () {
+	it.windowsBroken('encodeURIComponent()', function () {
 		var text;
 		should(Ti.Network.encodeURIComponent).be.a.Function;
 		text = Ti.Network.encodeURIComponent('Look what I found! I like this:');
@@ -90,7 +90,7 @@ describe('Titanium.Network', function () {
 		}
 	});
 
-	it.windowsPhone81Broken('decodeURIComponent()', function () {
+	it.windowsBroken('decodeURIComponent()', function () {
 		var text;
 		should(Ti.Network.decodeURIComponent).be.a.Function;
 		text = Ti.Network.decodeURIComponent('Look%20what%20I%20found!%20I%20like%20this%3A');

--- a/Resources/ti.ui.window.test.js
+++ b/Resources/ti.ui.window.test.js
@@ -110,7 +110,7 @@ describe('Titanium.UI.Window', function () {
 	});
 
 	// FIXME Move these rect/size tests into Ti.UI.View!
-	it.windowsDesktopBroken('.size is read-only', function (finish) {
+	it.windowsBroken('.size is read-only', function (finish) {
 		win = Ti.UI.createWindow({
 			backgroundColor: 'blue',
 			width: 100,
@@ -142,7 +142,7 @@ describe('Titanium.UI.Window', function () {
 		win.open();
 	});
 
-	it.androidAndWindowsDesktopBroken('.rect is read-only', function (finish) {
+	it.androidAndWindowsBroken('.rect is read-only', function (finish) {
 		win = Ti.UI.createWindow({
 			backgroundColor: 'green',
 			left: 100,


### PR DESCRIPTION
Skipping some failing tests for Windows. `Ti.Network.encode/decodeURIComponent` worked locally for me but I don't know why Jenkins is failing for this.