### PR TITLE
Improve Window cleanup

### DIFF
--- a/Resources/ti.ui.tableview.test.js
+++ b/Resources/ti.ui.tableview.test.js
@@ -20,11 +20,15 @@ describe('Titanium.UI.TableView', function () {
 		didFocus = false;
 	});
 
-	afterEach(function () {
+	afterEach(function (done) {
 		if (win) {
+			win.open();
+			win.addEventListener('close', function () {
+				done();
+				win = null;
+			});
 			win.close();
 		}
-		win = null;
 	});
 
 	it('Ti.UI.TableView', function () {


### PR DESCRIPTION
- Attempt to improve `Titanium.UI.Window` cleanup
- We call `open` to make sure the window is in an open state before we close it to receive the 'close' event