### PR TITLE
Skip ui.bootstrap for Windows because of parity issue

### DIFF
--- a/Resources/bootstraps/ui.bootstrap.js
+++ b/Resources/bootstraps/ui.bootstrap.js
@@ -24,7 +24,7 @@ exports.execute = function (finished) {
 	//
 	if (Ti.Platform.osname === 'windowsphone' || Ti.Platform.osname === 'windowsstore') {
 		global.wasUIBootstrapExecuted = true;
-		return finish();
+		return finished();
 	}
 	// Display a window. (This is the intended use-case for the bootstrap execute() method.)
 	var window = Ti.UI.createWindow({ exitOnClose: false });

--- a/Resources/bootstraps/ui.bootstrap.js
+++ b/Resources/bootstraps/ui.bootstrap.js
@@ -19,6 +19,13 @@ global.wasUIBootstrapLoaded = true;
 
 // To be called by Titanium's bootstrap loader on startup, but before the "app.js" gets executed.
 exports.execute = function (finished) {
+	//
+	// FIXME Windows: TIMOB-26457 - Window.exitOnClose doesn't work when only one Window is opened
+	//
+	if (Ti.Platform.osname === 'windowsphone' || Ti.Platform.osname === 'windowsstore') {
+		global.wasUIBootstrapExecuted = true;
+		return finish();
+	}
 	// Display a window. (This is the intended use-case for the bootstrap execute() method.)
 	var window = Ti.UI.createWindow({ exitOnClose: false });
 	window.add(Ti.UI.createLabel({ text: 'Bootstrapped UI' }));


### PR DESCRIPTION
Relates to [TIMOB-26457](https://jira.appcelerator.org/browse/TIMOB-26457).

`ui.bootstrap` script exits the app on Windows because of parity issue at `Window.close`.