### PR TITLE
Fix for unit tests using Ti.Map.View

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -114,6 +114,7 @@ function addTiAppProperties(next) {
 	const insertManifest = () => {
 		content.push('\t\t\t<application>');
 		content.push('\t\t\t\t<meta-data android:name="com.google.android.geo.API_KEY" android:value="AIzaSyCN_aC6RMaynan8YzsO1HNHbhsr9ZADDlY"/>');
+		content.push('\t\t\t\t<uses-library android:name="org.apache.http.legacy" android:required="false" />');
 		content.push('\t\t\t</application>');
 		content.push('\t\t\t<uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>');
 	};


### PR DESCRIPTION
Adds a in the tiapp.xml android override that is required for Google Maps API to work when targeting Android 9. This should stop our unit test depending on Ti.Map.View to randomly time out.

https://developers.google.com/maps/documentation/android-sdk/config#specify_requirement_for_apache_http_legacy_library