### PR TITLE
Enable HttpClient callback test for Windows

### DIFF
--- a/Resources/ti.network.httpclient.test.js
+++ b/Resources/ti.network.httpclient.test.js
@@ -372,8 +372,7 @@ describe('Titanium.Network.HTTPClient', function () {
 
 	// https://jira.appcelerator.org/browse/TIMOB-11751
 	// https://jira.appcelerator.org/browse/TIMOB-17403
-	// Windows Desktop is timing out here...
-	it.windowsBroken('callbackTestForGETMethod', function (finish) {
+	it('callbackTestForGETMethod', function (finish) {
 		var xhr = Ti.Network.createHTTPClient(),
 			attempts = 3,
 			dataStreamFinished = false;
@@ -415,8 +414,7 @@ describe('Titanium.Network.HTTPClient', function () {
 		xhr.send();
 	});
 
-	// Windows Desktop is timing out here...
-	it.windowsBroken('callbackTestForPOSTMethod', function (finish) {
+	it('callbackTestForPOSTMethod', function (finish) {
 		var xhr = Ti.Network.createHTTPClient(),
 			attempts = 3,
 			sendStreamFinished = false,


### PR DESCRIPTION
DO NOT MERGE

Jenkins fails for`callbackTestForGETMethod` on Jenkins.

https://github.com/appcelerator/titanium_mobile_windows/pull/1318 should enable HTTPClient callback tests for Windows.