### PR TITLE
Skip failing tests for Windows

### DIFF
--- a/Resources/core.runtime.test.js
+++ b/Resources/core.runtime.test.js
@@ -76,7 +76,8 @@ describe('Core', () => {
 						view.foo.should.be.equal('bar');
 					});
 
-					it('should properly handle properties with value of nil (TIMOB-26452)', () => {
+					// FIXME: Windows returns object instead of string
+					it.windowsBroken('should properly handle properties with value of nil (TIMOB-26452)', () => {
 						should(Ti.Geolocation).have.property('lastGeolocation');
 						if (utilities.isIOS()) {
 							should.not.exist(Ti.Geolocation.lastGeolocation);

--- a/Resources/timers.test.js
+++ b/Resources/timers.test.js
@@ -167,7 +167,8 @@ describe('Timers', function () {
 		});
 	});
 
-	it('should be able to override', function () {
+	// FIXME: Windows returns undefined for property descriptor. We might want a different way to get them.
+	it.windowsMissing('should be able to override', function () {
 		const methodNames = [ 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval' ];
 		for (const methodName of methodNames) {
 			const descriptor = Object.getOwnPropertyDescriptor(global, methodName);


### PR DESCRIPTION
- Windows returns object for `Ti.Geolocation.lastGeolocation` other than string
- Windows returns undefined for `Object.getOwnPropertyDescriptor`