### PR TITLE
Fix TabGroup "blur" unit test.

### DIFF
--- a/Resources/ti.ui.tabgroup.test.js
+++ b/Resources/ti.ui.tabgroup.test.js
@@ -238,7 +238,7 @@ describe('Titanium.UI.TabGroup', () => {
 			});
 
 			tabGroup.addEventListener('blur', () => finish());
-			tab.addEventListener('open', () => {
+			tabGroup.addEventListener('open', () => {
 				setTimeout(() => tabGroup.close(), 1);
 			});
 


### PR DESCRIPTION
Wait for for the TabGroup `open` event instead of a Tab's one. That is most likely a typo...