### PR TITLE
fix(windows): skip xml tests for Windows Phone

### DIFF
--- a/Resources/ti.xml.test.js
+++ b/Resources/ti.xml.test.js
@@ -10,7 +10,7 @@
 'use strict';
 var should = require('./utilities/assertions');
 
-describe.windowsDesktopBroken('Titanium.XML', function () {
+describe.windowsBroken('Titanium.XML', function () {
 	var testSource = {},
 		invalidSource = {};
 


### PR DESCRIPTION
Skip `Titanium.XML` tests for Windows Phone because it's crashing and blocking builds.