### PR TITLE
Revert "fix(windows): Temporarily disabled Ti.UI.WebView ms-appx-data"

### DIFF
--- a/Resources/ti.ui.webview.test.js
+++ b/Resources/ti.ui.webview.test.js
@@ -261,7 +261,7 @@ describe('Titanium.UI.WebView', function () {
 			w.open();
 		});
 
-		it.windowsBroken('ms-appx-data:', function (finish) {
+		it('ms-appx-data:', function (finish) {
 			var w,
 				webview;
 


### PR DESCRIPTION
This reverts #134. https://github.com/appcelerator/titanium_mobile_windows/pull/1378 should be making the tests more stable.