### PR TITLE
fix(android): include adb-all script

### DIFF
--- a/plugins/mocha.test.support/hooks/hook.js
+++ b/plugins/mocha.test.support/hooks/hook.js
@@ -26,7 +26,7 @@ exports.init = (logger, config, cli) => {
 
 	cli.on('build.post.compile', async (builder, done) => {
 		if (builder.platformName === 'android') {
-			await wakeDevices(logger, builder).catch(e => console.warn(`could not wake ${builder.deviceId}: ${e}`));
+			await wakeDevices(logger, builder).catch(e => logger.warn(`could not wake ${builder.deviceId}: ${e}`));
 		}
 		done();
 	});

--- a/scripts/adb-all.sh
+++ b/scripts/adb-all.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+DEVICES=`adb devices | tail  -n +2 | cut -sf 1`
+
+for DEVICE in $DEVICES
+do
+  RUN="adb -s $DEVICE $@"
+  ${RUN}
+done


### PR DESCRIPTION
- Include `adb-all` script to execute `adb` commands on all connected devices