### PR TITLE
fix: textfield.width test failure

### DIFF
--- a/Resources/ti.ui.textfield.test.js
+++ b/Resources/ti.ui.textfield.test.js
@@ -197,7 +197,7 @@ describe('Titanium.UI.TextField', function () {
 		win.addEventListener('focus', function () {
 			try {
 				should(win.width).be.greaterThan(100);
-				should(textfield.width).not.be.greaterThan(win.width);
+				should(textfield.width).eql(Ti.UI.SIZE);
 				return finish();
 			} catch (err) {
 				finish(err);


### PR DESCRIPTION
In `width` test case in textfield test, `textfield.width` should be `Ti.UI.SIZE` because SIZE is explicitly set to the textfield.

