### PR TITLE
fix: validate multiple valid outputs for inspect with object

### DIFF
--- a/Resources/util.test.js
+++ b/Resources/util.test.js
@@ -637,16 +637,15 @@ describe('util', () => {
 				func: function () {}
 			};
 			// In Node 10+, we can sort the properties to ensure order to match, otherwise JSC/V8 return arguments/caller in different order on Functions
-			let expected = '{ foo: \'bar\', foobar: 1, func: { [Function: func] [arguments]: null, [caller]: null, [length]: 0, [name]: \'func\', [prototype]: func { [constructor]: [Circular] } } }';
-			if (utilities.isAndroid()) {
+			let expected = [
+				'{ foo: \'bar\', foobar: 1, func: { [Function: func] [arguments]: null, [caller]: null, [length]: 0, [name]: \'func\', [prototype]: func { [constructor]: [Circular] } } }',
+
 				// FIXME: On V8/Android we are not getting 'arguments' and 'caller' properties!
 				// This may be because in newer specs/strict mode they shouldn't be accessible?
-				expected = '{ foo: \'bar\', foobar: 1, func: { [Function: func] [length]: 0, [name]: \'func\', [prototype]: func { [constructor]: [Circular] } } }';
-			} else if (utilities.isIOS() && greaterOrEqualTo(Ti.Platform.version, '12.2')) { // iOS 12.2 removed arguments/caller
-				expected = '{ foo: \'bar\', foobar: 1, func: { [Function: func] [length]: 0, [name]: \'func\', [prototype]: func { [constructor]: [Circular] } } }';
-			}
-			util.inspect(obj, { showHidden: true, breakLength: Infinity })
-				.should.eql(expected);
+				'{ foo: \'bar\', foobar: 1, func: { [Function: func] [length]: 0, [name]: \'func\', [prototype]: func { [constructor]: [Circular] } } }'
+			];
+
+			util.inspect(obj, { showHidden: true, breakLength: Infinity }).should.be.oneOf(expected);
 		});
 
 		it('with nested object and infinite depth', () => {
@@ -657,17 +656,15 @@ describe('util', () => {
 			};
 
 			// In Node 10+, we can sort the properties to ensure order to match, otheerwise JSC/V8 return arguments/caller in different order on Functions
-			let expected = '{ foo: \'bar\', foobar: 1, func: [ { a: { [Function: a] [arguments]: null, [caller]: null, [length]: 0, [name]: \'a\', [prototype]: a { [constructor]: [Circular] } } }, [length]: 1 ] }';
-			if (utilities.isAndroid()) {
+			let expected = [
+				'{ foo: \'bar\', foobar: 1, func: [ { a: { [Function: a] [arguments]: null, [caller]: null, [length]: 0, [name]: \'a\', [prototype]: a { [constructor]: [Circular] } } }, [length]: 1 ] }',
+
 				// FIXME: On V8/Android we are not getting 'arguments' and 'caller' properties!
 				// This may be because in newer specs/strict mode they shouldn't be accessible?
-				expected = '{ foo: \'bar\', foobar: 1, func: [ { a: { [Function: a] [length]: 0, [name]: \'a\', [prototype]: a { [constructor]: [Circular] } } }, [length]: 1 ] }';
-			} else if (utilities.isIOS() && greaterOrEqualTo(Ti.Platform.version, '12.2')) { // iOS 12.2 removed arguments/caller
-				expected = '{ foo: \'bar\', foobar: 1, func: [ { a: { [Function: a] [length]: 0, [name]: \'a\', [prototype]: a { [constructor]: [Circular] } } }, [length]: 1 ] }';
-			}
+				'{ foo: \'bar\', foobar: 1, func: [ { a: { [Function: a] [length]: 0, [name]: \'a\', [prototype]: a { [constructor]: [Circular] } } }, [length]: 1 ] }'
+			];
 
-			util.inspect(nestedObj2, { showHidden: true, breakLength: Infinity, depth: Infinity, sorted: true }).should.eql(
-				expected);
+			util.inspect(nestedObj2, { showHidden: true, breakLength: Infinity, depth: Infinity, sorted: true }).should.be.oneOf(expected);
 		});
 
 		it.skip('with nested object and default depth', () => {


### PR DESCRIPTION
- Allow output from either V8 or JavascriptCore as valid