### PR TITLE
chore: improve reliability of tests

### DIFF
--- a/Resources/app.js
+++ b/Resources/app.js
@@ -253,6 +253,9 @@ function $Reporter(runner) {
 	runner.on('fail', function (test, err) {
 		test.err = err;
 		failed = true;
+
+		const fixedNames = suiteAndTitle(suites, test.title);
+		Ti.API.error(`!TEST_FAIL: ${fixedNames.suite} - ${fixedNames.title} -> ${JSON.stringify(err)}`);
 	});
 
 	runner.on('test end', function (test) {

--- a/Resources/ti-mocha.js
+++ b/Resources/ti-mocha.js
@@ -4333,7 +4333,11 @@
 			function multiple(err) {
 				if (emitted) { return; }
 				emitted = true;
-				self.emit('error', err || new Error('done() called multiple times'));
+				if (err) {
+					self.emit('error', err);
+				} else {
+					Ti.API.warn('done() called multiple times');
+				}
 			}
 
 			// finished

--- a/Resources/ti.blob.test.js
+++ b/Resources/ti.blob.test.js
@@ -15,14 +15,28 @@ describe('Titanium.Blob', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it('.apiName', function () {

--- a/Resources/ti.map.test.js
+++ b/Resources/ti.map.test.js
@@ -18,14 +18,28 @@ describe('Titanium.Map', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	// FIXME Gives bad value for Android
@@ -184,26 +198,6 @@ describe('Titanium.Map', function () {
 
 	it('#createRoute()', function () {
 		should(Map.createRoute).be.a.Function;
-	});
-
-	it('#createView()', function () {
-		should(Map.createView).be.a.Function;
-
-		win = Ti.UI.createWindow();
-
-		const view = Map.createView({
-			mapType: Map.NORMAL_TYPE,
-			region: { // Mountain View
-				latitude: 37.3689,
-				longitude: -122.0353,
-				latitudeDelta: 0.1,
-				longitudeDelta: 0.1
-			}
-		});
-		should(view).be.a.Object;
-
-		win.add(view);
-		win.open();
 	});
 
 	// Intentional skip, constant only for Android

--- a/Resources/ti.media.videoplayer.test.js
+++ b/Resources/ti.media.videoplayer.test.js
@@ -22,14 +22,28 @@ describe('Titanium.Media.VideoPlayer', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it.windowsMissing('VIDEO_PLAYBACK_* constants', function () {

--- a/Resources/ti.ui.button.test.js
+++ b/Resources/ti.ui.button.test.js
@@ -16,14 +16,28 @@ describe('Titanium.UI.Button', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it('apiName', function () {

--- a/Resources/ti.ui.imageview.test.js
+++ b/Resources/ti.ui.imageview.test.js
@@ -16,14 +16,28 @@ describe('Titanium.UI.ImageView', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it('apiName', function () {

--- a/Resources/ti.ui.layout.test.js
+++ b/Resources/ti.ui.layout.test.js
@@ -18,24 +18,33 @@ function createWindow(_args) {
 }
 
 describe('Titanium.UI.Layout', function () {
-	var win,
-		didPostlayout = false;
+	var win;
 	this.timeout(5000);
-
-	beforeEach(function () {
-		didPostlayout = false;
-	});
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	// functional test cases #1010, #1011, #1025, #1025a
@@ -54,11 +63,8 @@ describe('Titanium.UI.Layout', function () {
 
 		win.add(view);
 		win.add(label);
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				Ti.API.info('Got postlayout');
@@ -122,11 +128,8 @@ describe('Titanium.UI.Layout', function () {
 
 		win.add(view);
 		win.add(view2);
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.left).eql(10);
@@ -162,11 +165,8 @@ describe('Titanium.UI.Layout', function () {
 
 		win.add(view);
 		win.add(view2);
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.top).eql(10);
@@ -200,11 +200,8 @@ describe('Titanium.UI.Layout', function () {
 		win = createWindow();
 
 		win.add(view);
-		view.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		view.addEventListener('postlayout', function listener () {
+			view.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.center.x).eql(50);
@@ -231,11 +228,8 @@ describe('Titanium.UI.Layout', function () {
 		win = createWindow();
 
 		win.add(view);
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.width).eql(10);
@@ -280,12 +274,8 @@ describe('Titanium.UI.Layout', function () {
 		win = createWindow();
 
 		win.add(view);
-		win.addEventListener('postlayout', function () {
-			// FIXME Never fires on iOS or Android! Maybe because window is the one firing the event?
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.left).eql('leftString');
@@ -331,11 +321,8 @@ describe('Titanium.UI.Layout', function () {
 
 		win = createWindow();
 
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view1.width).be.undefined;
@@ -381,11 +368,8 @@ describe('Titanium.UI.Layout', function () {
 
 		win = createWindow();
 
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view1.left).be.undefined;
@@ -419,11 +403,8 @@ describe('Titanium.UI.Layout', function () {
 	it('undefinedCenter', function (finish) {
 		var view = Ti.UI.createView({});
 		win = createWindow();
-		view.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		view.addEventListener('postlayout', function listener () {
+			view.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.center).be.undefined;
@@ -449,11 +430,8 @@ describe('Titanium.UI.Layout', function () {
 			left: 10
 		});
 		win = createWindow();
-		view.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		view.addEventListener('postlayout', function listener () {
+			view.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.right).be.undefined;
@@ -494,11 +472,8 @@ describe('Titanium.UI.Layout', function () {
 				bottom: 10
 			});
 		win = createWindow();
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view1.height).be.undefined;
@@ -540,11 +515,8 @@ describe('Titanium.UI.Layout', function () {
 				height: 100
 			});
 		win = createWindow();
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				// Static Tops
@@ -582,11 +554,8 @@ describe('Titanium.UI.Layout', function () {
 			top: 10
 		});
 		win = createWindow();
-		view.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		view.addEventListener('postlayout', function listener () {
+			view.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.bottom).be.undefined;
@@ -611,11 +580,8 @@ describe('Titanium.UI.Layout', function () {
 			width: 10
 		});
 		win = createWindow();
-		view.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		view.addEventListener('postlayout', function listener () {
+			view.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.size.width).eql(10);
@@ -641,11 +607,8 @@ describe('Titanium.UI.Layout', function () {
 		});
 		win = createWindow();
 
-		view.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		view.addEventListener('postlayout', function listener () {
+			view.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.size.width).eql(40); // FIXME Android gives expected 210 to equal 40
@@ -674,11 +637,8 @@ describe('Titanium.UI.Layout', function () {
 				right: 50
 			});
 		win = createWindow();
-		viewChild.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		viewChild.addEventListener('postlayout', function listener () {
+			viewChild.removeEventListener('postlayout', listener);
 
 			try {
 				should(viewChild.size.width).eql(100); // FIXME Android/Windows give "expected 150 to equal 100"
@@ -702,11 +662,8 @@ describe('Titanium.UI.Layout', function () {
 			height: 10
 		});
 		win = createWindow();
-		view.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		view.addEventListener('postlayout', function listener () {
+			view.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.size.height).eql(10);
@@ -731,11 +688,8 @@ describe('Titanium.UI.Layout', function () {
 			}
 		});
 		win = createWindow();
-		view.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		view.addEventListener('postlayout', function listener () {
+			view.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.size.height).eql(40);// FIXME Android gives "expected 290 to equal 40"
@@ -764,11 +718,8 @@ describe('Titanium.UI.Layout', function () {
 				bottom: 50
 			});
 		win = createWindow();
-		viewChild.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		viewChild.addEventListener('postlayout', function listener () {
+			viewChild.removeEventListener('postlayout', listener);
 
 			try {
 				should(viewChild.size.height).eql(100); // FIXME "expected 150 to equal 100" on Android/Windows
@@ -827,11 +778,8 @@ describe('Titanium.UI.Layout', function () {
 		//	showVerticalScrollIndicator: true,
 		//	showHorizontalScrollIndicator: true
 		// });
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				// LABEL HAS SIZE AUTO BEHAVIOR.
@@ -913,11 +861,8 @@ describe('Titanium.UI.Layout', function () {
 				top: 50
 			});
 		win = createWindow();
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view1.zIndex).eql(0);
@@ -950,11 +895,8 @@ describe('Titanium.UI.Layout', function () {
 		parent.add(child);
 		win.add(parent);
 
-		parent.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		parent.addEventListener('postlayout', function listener () {
+			parent.removeEventListener('postlayout', listener);
 
 			try {
 				should(parent.size.width).eql(40);
@@ -994,11 +936,8 @@ describe('Titanium.UI.Layout', function () {
 		grandParent.add(parent);
 		win.add(grandParent);
 
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(grandParent.size.width).eql(200);
@@ -1032,11 +971,8 @@ describe('Titanium.UI.Layout', function () {
 		parent.add(child);
 		win.add(parent);
 
-		parent.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		parent.addEventListener('postlayout', function listener () {
+			parent.removeEventListener('postlayout', listener);
 
 			try {
 				if (utilities.isAndroid()) {
@@ -1078,11 +1014,8 @@ describe('Titanium.UI.Layout', function () {
 		win.add(child1);
 		win.add(child2);
 
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(child.size.width).not.be.eql(0); // FIXME Windows Desktop gives: expected 0 not to equal 0
@@ -1115,11 +1048,8 @@ describe('Titanium.UI.Layout', function () {
 		win = Ti.UI.createWindow();
 		scrollView.add(view2);
 
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view2.size.width).eql(scrollView.size.width);
@@ -1145,11 +1075,8 @@ describe('Titanium.UI.Layout', function () {
 		win = Ti.UI.createWindow();
 		scrollView.add(view2);
 
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view2.size.width).eql(scrollView.size.width);
@@ -1175,11 +1102,8 @@ describe('Titanium.UI.Layout', function () {
 		win = Ti.UI.createWindow();
 		scrollView.add(view2);
 
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view2.size.width).eql(scrollView.size.width);
@@ -1206,11 +1130,8 @@ describe('Titanium.UI.Layout', function () {
 		win = Ti.UI.createWindow();
 		scrollView.add(view2);
 
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view2.size.width).eql(scrollView.size.width);
@@ -1237,11 +1158,8 @@ describe('Titanium.UI.Layout', function () {
 		win = Ti.UI.createWindow();
 		scrollView.add(view2);
 
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 
 			try {
 				should(view2.size.width).eql(scrollView.size.width);
@@ -1285,11 +1203,8 @@ describe('Titanium.UI.Layout', function () {
 		win.add(NavBarView);
 		win.add(scrollView);
 
-		scrollView.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		scrollView.addEventListener('postlayout', function listener () {
+			scrollView.removeEventListener('postlayout', listener);
 
 			try {
 				should(scrollView.size.height).eql(50);
@@ -1332,11 +1247,8 @@ describe('Titanium.UI.Layout', function () {
 		win.add(NavBarView);
 		win.add(scrollView);
 
-		scrollView.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		scrollView.addEventListener('postlayout', function listener () {
+			scrollView.removeEventListener('postlayout', listener);
 
 			try {
 				should(scrollView.size.height).eql(300);
@@ -1380,11 +1292,8 @@ describe('Titanium.UI.Layout', function () {
 			}));
 		}
 
-		scrollView.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		scrollView.addEventListener('postlayout', function listener () {
+			scrollView.removeEventListener('postlayout', listener);
 
 			try {
 				should(innerView.size.height).eql(1200); // FIXME iOS gives "expected 0 to equal 1200"
@@ -1412,11 +1321,8 @@ describe('Titanium.UI.Layout', function () {
 		view.add(inner_view);
 		win.add(view);
 
-		inner_view.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		inner_view.addEventListener('postlayout', function listener () {
+			inner_view.removeEventListener('postlayout', listener);
 
 			try {
 				should(inner_view.size.width).eql(80);
@@ -1446,11 +1352,8 @@ describe('Titanium.UI.Layout', function () {
 		view.add(inner_view);
 		win.add(view);
 
-		inner_view.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		inner_view.addEventListener('postlayout', function listener () {
+			inner_view.removeEventListener('postlayout', listener);
 
 			try {
 				should(inner_view.size.width).eql(80);
@@ -1487,11 +1390,8 @@ describe('Titanium.UI.Layout', function () {
 		win = createWindow();
 		view.add(innerView);
 
-		view.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		view.addEventListener('postlayout', function listener () {
+			view.removeEventListener('postlayout', listener);
 
 			try {
 				should(view.size.height).eql(innerView.size.height);
@@ -1526,7 +1426,9 @@ describe('Titanium.UI.Layout', function () {
 				bottom: 10,
 			});
 		win = createWindow();
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				should(a.rect.x).eql(10); // iOS gives 0
 				should(a.rect.y).eql(10);
@@ -1567,7 +1469,9 @@ describe('Titanium.UI.Layout', function () {
 			});
 		win = createWindow();
 
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				should(view.rect.x).eql(10);
 				should(view.rect.y).eql(10);
@@ -1610,7 +1514,9 @@ describe('Titanium.UI.Layout', function () {
 
 		win = createWindow();
 
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				should(view.rect.x).eql(10);
 				should(view.rect.y).eql(10);
@@ -1652,7 +1558,9 @@ describe('Titanium.UI.Layout', function () {
 
 		win = createWindow();
 
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				should(view.rect.x).eql(10);
 				should(view.rect.y).eql(10);
@@ -1693,7 +1601,9 @@ describe('Titanium.UI.Layout', function () {
 
 		win = createWindow();
 
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				should(view.rect.x).eql(10);
 				should(view.rect.y).eql(10);
@@ -1736,7 +1646,9 @@ describe('Titanium.UI.Layout', function () {
 
 		win = createWindow();
 
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				should(view.rect.x).eql(10);
 				should(view.rect.y).eql(10);
@@ -1779,7 +1691,9 @@ describe('Titanium.UI.Layout', function () {
 
 		win = createWindow();
 
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				should(view.rect.x).eql(10);
 				should(view.rect.y).eql(10);
@@ -1812,7 +1726,9 @@ describe('Titanium.UI.Layout', function () {
 
 		win = createWindow();
 
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				should(label.rect.x).eql(10);
 				should(label.rect.width).eql(win.rect.width - 20);
@@ -1840,7 +1756,9 @@ describe('Titanium.UI.Layout', function () {
 
 		win = createWindow();
 
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				should(label.rect.x).eql(10);
 				should(label.rect.width).eql(win.rect.width - 20); // Android gives us 97, should be 1260
@@ -1868,7 +1786,9 @@ describe('Titanium.UI.Layout', function () {
 
 		win = createWindow({ layout: 'vertical' });
 
-		label.addEventListener('postlayout', function () {
+		label.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				should(label.rect.x).eql(10);
 				should(label.rect.width).eql(win.rect.width - 20);
@@ -1894,11 +1814,9 @@ describe('Titanium.UI.Layout', function () {
 
 		win = createWindow();
 
-		win.addEventListener('postlayout', function () {
-			if (didPostlayout) {
-				return;
-			}
-			didPostlayout = true;
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				savedRect = label.rect;
 				should(label.rect.width).not.eql(0);
@@ -1944,7 +1862,9 @@ describe('Titanium.UI.Layout', function () {
 			backgroundColor: 'red',
 		});
 		win = createWindow();
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				should(v1.rect.x).eql(0);
 				should(v1.rect.y).eql(0);

--- a/Resources/ti.ui.listview.test.js
+++ b/Resources/ti.ui.listview.test.js
@@ -16,14 +16,28 @@ describe('Titanium.UI.ListView', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it('Ti.UI.ListView', function () {
@@ -942,7 +956,8 @@ describe('Titanium.UI.ListView', function () {
 		listView.setSections([ section ]);
 
 		// should not crash after drawing listView
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 			finish();
 		});
 

--- a/Resources/ti.ui.maskedimage.test.js
+++ b/Resources/ti.ui.maskedimage.test.js
@@ -14,15 +14,29 @@ var should = require('./utilities/assertions');
 describe.windowsMissing('Titanium.UI.MaskedImage', function () {
 	var win;
 
-	afterEach(function (finish) {
+	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
-				finish();
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
+				done();
 			});
 			win.close();
-			win = null;
 		} else {
-			finish();
+			win = null;
+			done();
 		}
 	});
 
@@ -54,7 +68,8 @@ describe.windowsMissing('Titanium.UI.MaskedImage', function () {
 			width: Ti.UI.FILL,
 			height: Ti.UI.FILL,
 		}));
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 			// Assume MaskedImage has rendered successfully by this point.
 			finish();
 		});
@@ -71,7 +86,8 @@ describe.windowsMissing('Titanium.UI.MaskedImage', function () {
 			width: Ti.UI.FILL,
 			height: Ti.UI.FILL,
 		}));
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 			// Assume MaskedImage has rendered successfully by this point.
 			finish();
 		});

--- a/Resources/ti.ui.picker.test.js
+++ b/Resources/ti.ui.picker.test.js
@@ -19,14 +19,28 @@ describe('Titanium.UI.Picker', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it('DatePicker', function (finish) {

--- a/Resources/ti.ui.scrollableview.test.js
+++ b/Resources/ti.ui.scrollableview.test.js
@@ -14,15 +14,29 @@ describe('Titanium.UI.ScrollableView', function () {
 	var win;
 	this.timeout(5000);
 
-	afterEach(function (finish) {
+	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
-				finish();
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
+				done();
 			});
 			win.close();
-			win = null;
 		} else {
-			finish();
+			win = null;
+			done();
 		}
 	});
 

--- a/Resources/ti.ui.scrollview.test.js
+++ b/Resources/ti.ui.scrollview.test.js
@@ -16,14 +16,28 @@ describe('Titanium.UI.ScrollView', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it('apiName', function () {

--- a/Resources/ti.ui.searchbar.test.js
+++ b/Resources/ti.ui.searchbar.test.js
@@ -15,14 +15,28 @@ describe('Titanium.UI.SearchBar', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it.ios('.showBookmark', function () {

--- a/Resources/ti.ui.shortcutitem.test.js
+++ b/Resources/ti.ui.shortcutitem.test.js
@@ -34,6 +34,12 @@ describe('Titanium.UI.ShortcutItem', () => {
 		should(shortcut).have.readOnlyProperty('apiName').which.is.a.String;
 		should(shortcut.apiName).be.eql('Ti.UI.ShortcutItem');
 
+		// ONLY compatible with Android 7.1+, end test early
+		const version = Ti.Platform.version.split('.');
+		if (parseInt(`${version[0]}${version[1]}`) < 71) {
+			return;
+		}
+
 		// verify `id`
 		should(shortcut.id).be.eql('test_shortcut');
 

--- a/Resources/ti.ui.tabbedbar.test.js
+++ b/Resources/ti.ui.tabbedbar.test.js
@@ -18,11 +18,30 @@ describe.windowsMissing('Titanium.UI.TabbedBar', function () {
 		win = Ti.UI.createWindow();
 	});
 
-	afterEach(() => {
+	afterEach(function (done) {
 		if (win) {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
+				done();
+			});
 			win.close();
+		} else {
+			win = null;
+			done();
 		}
-		win = null;
 	});
 
 	it('apiName', () => {

--- a/Resources/ti.ui.tabgroup.test.js
+++ b/Resources/ti.ui.tabgroup.test.js
@@ -11,22 +11,39 @@
 const should = require('./utilities/assertions'); // eslint-disable-line no-unused-vars
 
 // skipping many test on Windows due to lack of event firing, see https://jira.appcelerator.org/browse/TIMOB-26690
-describe('Titanium.UI.TabGroup', () => {
+describe('Titanium.UI.TabGroup', function () {
 	let tabGroup;
+
+	this.timeout(5000);
 
 	afterEach(function (done) {
 		if (tabGroup) {
-			tabGroup.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (tabGroup) {
+					tabGroup = null;
+					done();
+				}
+			}, 3000);
+
+			tabGroup.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (tabGroup) {
+					tabGroup.removeEventListener('close', listener);
+				}
+				tabGroup = null;
 				done();
 			});
 			tabGroup.close();
-			tabGroup = null;
 		} else {
+			tabGroup = null;
 			done();
 		}
 	});
 
 	it.windowsBroken('add Map.View to TabGroup', function (finish) {
+		this.slow(5000);
 		this.timeout(10000);
 
 		const map = require('ti.map');
@@ -206,7 +223,10 @@ describe('Titanium.UI.TabGroup', () => {
 			tabGroup.addEventListener('open', () => {
 				setTimeout(() => tabGroup.close(), 1);
 			});
-			tabGroup.addEventListener('close', () => finish());
+			tabGroup.addEventListener('close', function listener () {
+				tabGroup.removeEventListener('close', listener);
+				finish();
+			});
 
 			tabGroup.addTab(tab);
 			tabGroup.open();
@@ -222,11 +242,10 @@ describe('Titanium.UI.TabGroup', () => {
 				title: 'Tab'
 			});
 
-			function done() {
-				tabGroup.removeEventListener('focus', done);
+			tabGroup.addEventListener('focus', function listener () {
+				tabGroup.removeEventListener('focus', listener);
 				finish();
-			}
-			tabGroup.addEventListener('focus', done);
+			});
 
 			tabGroup.addTab(tab);
 			tabGroup.open();

--- a/Resources/ti.ui.tabgroup.test.js
+++ b/Resources/ti.ui.tabgroup.test.js
@@ -18,7 +18,7 @@ describe('Titanium.UI.TabGroup', function () {
 
 	afterEach(function (done) {
 		if (tabGroup) {
-			// If `win` is already closed, we're done.
+			// If `tabGroup` is already closed, we're done.
 			let t = setTimeout(function () {
 				if (tabGroup) {
 					tabGroup = null;
@@ -48,7 +48,10 @@ describe('Titanium.UI.TabGroup', function () {
 
 		const map = require('ti.map');
 		const mapView = map.createView({ top: 0, height: '80%' });
-		mapView.addEventListener('complete', () => finish());
+		mapView.addEventListener('complete', function listener () {
+			mapView.removeEventListener('complete', listener);
+			finish();
+		});
 
 		const win = Ti.UI.createWindow();
 		win.add(mapView);

--- a/Resources/ti.ui.tableview.test.js
+++ b/Resources/ti.ui.tableview.test.js
@@ -17,14 +17,28 @@ describe('Titanium.UI.TableView', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it('Ti.UI.TableView', function () {

--- a/Resources/ti.ui.test.js
+++ b/Resources/ti.ui.test.js
@@ -18,14 +18,28 @@ describe('Titanium.UI', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	(utilities.isWindows() ? describe.skip : describe)('#convertUnits()', function () {

--- a/Resources/ti.ui.textarea.test.js
+++ b/Resources/ti.ui.textarea.test.js
@@ -15,14 +15,28 @@ describe('Titanium.UI.TextArea', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it('apiName', function () {

--- a/Resources/ti.ui.textfield.test.js
+++ b/Resources/ti.ui.textfield.test.js
@@ -16,14 +16,28 @@ describe('Titanium.UI.TextField', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it('apiName', function () {
@@ -192,7 +206,8 @@ describe('Titanium.UI.TextField', function () {
 			backgroundColor: '#ddd'
 		});
 		win.add(textfield);
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 			try {
 				should(win.rect.width).be.greaterThan(100);
 				should(textfield.rect.width).not.be.greaterThan(win.rect.width);
@@ -270,7 +285,9 @@ describe('Titanium.UI.TextField', function () {
 		win.add(textField);
 
 		// Start the test when the window has been opened.
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			setTimeout(function () {
 				textField.focus();
 			}, 500);
@@ -290,7 +307,8 @@ describe('Titanium.UI.TextField', function () {
 			finish(new Error('TextField wrongly received focus on open.'));
 		});
 		win.add(textField);
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
 			// If we made it this far, assume TextField did not receive focus.
 			finish();
 		});

--- a/Resources/ti.ui.webview.test.js
+++ b/Resources/ti.ui.webview.test.js
@@ -18,14 +18,28 @@ describe('Titanium.UI.WebView', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	// FIXME: I think we need to tweak the test here. Set URL property after adding the listeners!

--- a/Resources/ti.ui.window.test.js
+++ b/Resources/ti.ui.window.test.js
@@ -17,14 +17,28 @@ describe('Titanium.UI.Window', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it('.title', function () {
@@ -97,7 +111,9 @@ describe('Titanium.UI.Window', function () {
 			width: 100,
 			height: 100
 		});
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				win.size.width.should.eql(100);
 				win.size.height.should.eql(100);
@@ -129,8 +145,10 @@ describe('Titanium.UI.Window', function () {
 			left: 100,
 			right: 100
 		});
-		win.addEventListener('postlayout', function () {
-			var width,
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
+			let width,
 				height;
 			try {
 				win.rect.x.should.eql(100); // get 0 on Android
@@ -167,7 +185,9 @@ describe('Titanium.UI.Window', function () {
 			backgroundColor: 'gray'
 		});
 		view = Ti.UI.createView();
-		win.addEventListener('focus', function () {
+		win.addEventListener('focus', function listener () {
+			win.removeEventListener('focus', listener);
+
 			try {
 				should(win.children.length).be.eql(1);
 				win.remove(win.children[0]);
@@ -190,7 +210,9 @@ describe('Titanium.UI.Window', function () {
 			win = Ti.UI.createWindow({ backgroundColor: 'yellow' });
 
 			// Confirms that Ti.UI.Window fires postlayout event
-			win.addEventListener('postlayout', function () {
+			win.addEventListener('postlayout', function listener () {
+				win.removeEventListener('postlayout', listener);
+
 				finish();
 			});
 			win.open();
@@ -246,13 +268,14 @@ describe('Titanium.UI.Window', function () {
 			win = Ti.UI.createWindow({
 				backgroundColor: 'pink'
 			});
-			win.addEventListener('close', function () {
+			win.addEventListener('close', function listener () {
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
 				finish();
 			});
-			win.addEventListener('open', function () {
-				setTimeout(function () {
-					win.close();
-				}, 500);
+			win.addEventListener('open', function listener () {
+				win.close();
 			});
 			win.open();
 		});
@@ -628,10 +651,14 @@ describe('Titanium.UI.Window', function () {
 	});
 
 	it.android('.safeAreaPadding with extendSafeArea false', function (finish) {
+		this.slow(5000);
+
 		win = Ti.UI.createWindow({
 			extendSafeArea: false,
 		});
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				var padding = win.safeAreaPadding;
 				should(padding).be.a.Object;
@@ -649,13 +676,17 @@ describe('Titanium.UI.Window', function () {
 
 	// This test will only pass on Android 4.4 and higher since older versions do not support translucent bars.
 	it.android('.safeAreaPadding with extendSafeArea true', function (finish) {
+		this.slow(5000);
+
 		win = Ti.UI.createWindow({
 			extendSafeArea: true,
 			theme: 'Theme.AppCompat.NoTitleBar',
 			orientationModes: [ Ti.UI.PORTRAIT ],
 			windowFlags: Ti.UI.Android.FLAG_TRANSLUCENT_STATUS | Ti.UI.Android.FLAG_TRANSLUCENT_NAVIGATION
 		});
-		win.addEventListener('postlayout', function () {
+		win.addEventListener('postlayout', function listener () {
+			win.removeEventListener('postlayout', listener);
+
 			try {
 				var padding = win.safeAreaPadding;
 				should(padding).be.a.Object;
@@ -678,7 +709,9 @@ describe('Titanium.UI.Window', function () {
 		win = Ti.UI.createNavigationWindow({
 			window: window
 		});
-		window.addEventListener('postlayout', function () {
+		window.addEventListener('postlayout', function listener () {
+			window.removeEventListener('postlayout', listener);
+
 			try {
 				var padding = window.safeAreaPadding;
 				should(padding).be.a.Object;

--- a/Resources/ti.utils.test.js
+++ b/Resources/ti.utils.test.js
@@ -18,14 +18,28 @@ describe('Titanium.Utils', function () {
 
 	afterEach(function (done) {
 		if (win) {
-			win.addEventListener('close', function () {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
 				done();
 			});
 			win.close();
 		} else {
+			win = null;
 			done();
 		}
-		win = null;
 	});
 
 	it('exists', function () {


### PR DESCRIPTION
- Improve `Ti.UI.Window` cleanup after tests
- Remove listeners to prevent multiple `finish()` calls
- Warn when `finish()` is called multiple times instead of throwing an error
- Print `!TEST_FAIL` logs when a test fails