### PR TITLE
test: skip file test that crashes Windows

### DIFF
--- a/Resources/ti.filesystem.file.test.js
+++ b/Resources/ti.filesystem.file.test.js
@@ -740,7 +740,7 @@ describe('Titanium.Filesystem.File', function () {
 			should.not.exist(result); // null or undefined // FIXME: ios returns undefined, test checked for exactly null before
 		});
 
-		it('can access resource directory files', function () {
+		it.windowsBroken('can access resource directory files', function () {
 			let rootDir = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory),
 				rootPath,
 				filesFound = {};


### PR DESCRIPTION
Skip file test that makes Windows tests unstable for some reason.