### PR TITLE
test: enable Windows TabGroup test again

### DIFF
--- a/Resources/ti.filesystem.filestream.test.js
+++ b/Resources/ti.filesystem.filestream.test.js
@@ -166,6 +166,7 @@ describe('Titanium.Filesystem.FileStream', function () {
 	});
 
 	it('fileStreamPumpTest', function (finish) {
+		this.timeout(5000);
 		var pumpInputFile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, 'stream_test_in.txt');
 		should(pumpInputFile).be.an.Object;
 		should(pumpInputFile.open).be.a.Function;

--- a/Resources/ti.ui.tabgroup.test.js
+++ b/Resources/ti.ui.tabgroup.test.js
@@ -10,7 +10,6 @@
 'use strict';
 const should = require('./utilities/assertions'); // eslint-disable-line no-unused-vars
 
-// skipping many test on Windows due to lack of event firing, see https://jira.appcelerator.org/browse/TIMOB-26690
 describe('Titanium.UI.TabGroup', function () {
 	let tabGroup;
 
@@ -462,7 +461,7 @@ describe('Titanium.UI.TabGroup', function () {
 		});
 	});
 
-	it.windowsBroken('icon-only tabs - default style', (finish) => { // https://jira.appcelerator.org/browse/TIMOB-27264
+	it('icon-only tabs - default style', (finish) => {
 		this.timeout(5000);
 		tabGroup = Ti.UI.createTabGroup({
 			tabs: [


### PR DESCRIPTION
Attemp to stabilize Windows tests

- enable Windows TabGroup test again
- Increase filestream pump timeout

