### PR TITLE
fix: skip 'constructed via URIs' tests on Windows

### DIFF
--- a/Resources/ti.filesystem.file.test.js
+++ b/Resources/ti.filesystem.file.test.js
@@ -827,7 +827,7 @@ describe('Titanium.Filesystem.File', function () {
 		should(destFile.exists()).eql(true);
 	});
 
-	describe('constructed via URIs', () => {
+	describe.windowsBroken('constructed via URIs', () => {
 		let noSchemeTempAppJS;
 		let fileURI;
 		before(() => {


### PR DESCRIPTION
Skip URI file tests on Windows because it's broken