### PR TITLE
fix: skip 'constructed via URIs' tests on Windows (#205)

### DIFF
--- a/Resources/ti.filesystem.file.test.js
+++ b/Resources/ti.filesystem.file.test.js
@@ -827,7 +827,7 @@ describe('Titanium.Filesystem.File', function () {
 		should(destFile.exists()).eql(true);
 	});
 
-	describe('constructed via URIs', () => {
+	describe.windowsBroken('constructed via URIs', () => {
 		let noSchemeTempAppJS;
 		let fileURI;
 		before(() => {


### PR DESCRIPTION
Cherry-pick #205 for 8_3_X