### PR TITLE
fix: change url for useragent test

### DIFF
--- a/Resources/ti.ui.webview.test.js
+++ b/Resources/ti.ui.webview.test.js
@@ -321,19 +321,17 @@ describe('Titanium.UI.WebView', function () {
 		});
 	});
 
-	// FIXME: On Windows, this times-out. Probably need a longer timeout here?
-	// FIXME: On Android, 'e.source.html' sometimes returns null. May need to retry.
-	it.androidAndWindowsBroken('userAgent', function (finish) {
+	it('userAgent', function (finish) {
 		var webView = Ti.UI.createWebView({
 				userAgent: 'TEST AGENT'
 			}),
-			url = 'http://www.whatsmyua.info',
+			url = 'https://www.whoishostingthis.com/tools/user-agent/',
 			retry = 3;
 
 		win = Ti.UI.createWindow({ backgroundColor: 'gray' });
 
 		webView.addEventListener('load', function (e) {
-			var exp = /"input">(.*)<\/textarea/g.exec(e.source.html),
+			var exp = /"info-box user-agent">(.*)<\/div>/g.exec(e.source.html),
 				userAgent = exp && exp.length > 1 ? exp[1] : undefined;
 			if (userAgent && userAgent === webView.userAgent) {
 				finish();

--- a/Resources/ti.ui.webview.test.js
+++ b/Resources/ti.ui.webview.test.js
@@ -321,7 +321,7 @@ describe('Titanium.UI.WebView', function () {
 		});
 	});
 
-	it('userAgent', function (finish) {
+	it.windowsBroken('userAgent', function (finish) {
 		var webView = Ti.UI.createWebView({
 				userAgent: 'TEST AGENT'
 			}),


### PR DESCRIPTION
Previous URL has an expired cert, this seems to be good for another 6 months

Tested android and ios locally and they both look good, going to see how windows works on jenkins so hold off on the merge I guess