### PR TITLE
Fix DatePicker minDate test.

### DIFF
--- a/Resources/ti.ui.picker.test.js
+++ b/Resources/ti.ui.picker.test.js
@@ -298,7 +298,7 @@ describe('Titanium.UI.Picker', function () {
 
 	it('DatePicker minDate', function (finish) {
 		var dp = Ti.UI.createPicker({
-			titleype: Ti.UI.PICKER_TYPE_DATE
+			type: Ti.UI.PICKER_TYPE_DATE
 		});
 		var date = new Date(2018, 1, 1);
 		dp.setMinDate(date);


### PR DESCRIPTION
Fixes a typo in DatePicker's minDate test. That was caught with after the change in https://github.com/appcelerator/titanium_mobile/pull/11369