### PR TITLE
chore: remove usage of pastebin endpoint

### DIFF
--- a/Resources/ti.network.socket.tcp.test.js
+++ b/Resources/ti.network.socket.tcp.test.js
@@ -77,7 +77,7 @@ describe('Titanium.Network.Socket.TCP', function () {
 	it('#connect() and receive data', function (finish) {
 		var buffer = '';
 		socket = Ti.Network.Socket.createTCP({
-			host: 'pastebin.com', port: 80,
+			host: 'www.httpbin.org', port: 80,
 			timeout: 20000,
 			connected: function (e) {
 				// receive callback
@@ -90,7 +90,7 @@ describe('Titanium.Network.Socket.TCP', function () {
 					// end of stream
 					// note: iOS e.buffer will be `null` where Android wont
 					if (e.bytesProcessed === -1) {
-						if (buffer.indexOf('SUCCESS!') !== -1) {
+						if (buffer.indexOf('SUCCESS') !== -1) {
 							finish();
 						} else {
 							finish(new Error('failed to receive success'));
@@ -101,7 +101,7 @@ describe('Titanium.Network.Socket.TCP', function () {
 				// send GET request
 				should(socket.write).not.be.null;
 				should(socket.write).be.a.Function;
-				socket.write(Ti.createBuffer({ value: 'GET /raw/eF5dK0xU HTTP/1.1\r\nHost: pastebin.com\r\nConnection: close\r\n\r\n' }));
+				socket.write(Ti.createBuffer({ value: 'GET /anything?q=SUCCESS HTTP/1.1\r\nHost: www.httpbin.org\r\nConnection: close\r\n\r\n' }));
 			},
 			error: function (e) {
 				finish(e);
@@ -141,7 +141,7 @@ describe('Titanium.Network.Socket.TCP', function () {
 	it('#connect(), #write(), #pump() async', function (finish) {
 		var buffer = '';
 		socket = Ti.Network.Socket.createTCP({
-			host: 'pastebin.com',
+			host: 'www.httpbin.org',
 			port: 80,
 			timeout: 20000,
 			connected: function (e) {
@@ -152,7 +152,7 @@ describe('Titanium.Network.Socket.TCP', function () {
 				// send GET request
 				should(socket.write).not.be.null;
 				should(socket.write).be.a.Function;
-				socket.write(Ti.createBuffer({ value: 'GET /raw/eF5dK0xU HTTP/1.1\r\nHost: pastebin.com\r\nConnection: close\r\n\r\n' }), function (evt) {
+				socket.write(Ti.createBuffer({ value: 'GET /anything?q=SUCCESS HTTP/1.1\r\nHost: www.httpbin.org\r\nConnection: close\r\n\r\n' }), function (evt) {
 					evt.success.should.eql(true);
 
 					Ti.Stream.pump(e.socket, function (e) {
@@ -162,7 +162,7 @@ describe('Titanium.Network.Socket.TCP', function () {
 						// end of stream
 						// note: iOS e.buffer will be `null` where Android wont
 						if (e.bytesProcessed === -1) {
-							if (buffer.indexOf('SUCCESS!') !== -1) {
+							if (buffer.indexOf('SUCCESS') !== -1) {
 								finish();
 							} else {
 								finish(new Error('failed to receive success'));


### PR DESCRIPTION
- Remove usage of `pastebin.com` endpoint for TCP tests