### PR TITLE
chore: compare Ti.version with SDK version used

### DIFF
--- a/Resources/ti.test.js
+++ b/Resources/ti.test.js
@@ -19,6 +19,8 @@ describe('Titanium', () => {
 		should(Ti).have.readOnlyProperty('version').which.is.a.String();
 		should(Ti.version).not.eql('__VERSION__'); // This is the placeholder value used in iOS, let's ensure we replaced it!
 		should(Ti.version).match(/\d+\.\d+\.\d+/); // i.e. '9.0.0' (the short version string, no timestamp qualifier)
+		// Build plugin "mocha.test.support" stores SDK version to app properties.
+		should(Ti.version).eql(Ti.App.Properties.getString('Ti.version'));
 	});
 
 	it('#getVersion()', () => {

--- a/plugins/mocha.test.support/hooks/hook.js
+++ b/plugins/mocha.test.support/hooks/hook.js
@@ -24,6 +24,11 @@ exports.init = (logger, config, cli) => {
 	// Set ADB path
 	ADB_PATH = path.join(ANDROID_SDK, 'platform-tools', 'adb');
 
+	cli.on('build.pre.compile', async (builder, done) => {
+		builder.tiapp.properties['Ti.version'] = { type: 'string', value: builder.titaniumSdkVersion };
+		done();
+	});
+
 	cli.on('build.post.compile', async (builder, done) => {
 		if (builder.platformName === 'android') {
 			await wakeDevices(logger, builder).catch(e => logger.warn(`could not wake ${builder.deviceId}: ${e}`));


### PR DESCRIPTION
**Summary:**
Uses a plugin to fetch the version string used to build the app, store it to app properties, and compare it against `Ti.version` at runtime.

**Note:**
We had a bug in Android where library was wrongly returning "1.0.0" for `Ti.version`.
