### PR TITLE
chore: added Ti.Platform.openURL() tests

### DIFF
--- a/Resources/ti.android.test.js
+++ b/Resources/ti.android.test.js
@@ -34,8 +34,9 @@ describe.android('Titanium.Android', function () {
 		newIntent.putExtra('MyBoolean', true);
 		newIntent.putExtra('MyDouble', 123.456);
 		newIntent.putExtra('MyString', 'Hello World');
-		Ti.Android.rootActivity.addEventListener('newintent', function (e) {
+		Ti.Android.rootActivity.addEventListener('newintent', function listener(e) {
 			try {
+				Ti.Android.rootActivity.removeEventListener('newintent', listener);
 				function validateIntent(intent) {
 					should(intent).be.a.Object();
 					should(intent.action).eql(newIntent.action);

--- a/Resources/ti.platform.test.js
+++ b/Resources/ti.platform.test.js
@@ -19,8 +19,8 @@ describe('Titanium.Platform', function () {
 
 	it('canOpenURL()', () => {
 		should(Ti.Platform.canOpenURL).be.a.Function();
-		should(Ti.Platform.canOpenURL('http://www.appcelerator.com/')).be.eql(true);
-		should(Ti.Platform.canOpenURL('mocha://')).be.eql(true);
+		should(Ti.Platform.canOpenURL('http://www.appcelerator.com/')).be.true();
+		should(Ti.Platform.canOpenURL('mocha://')).be.true();
 	});
 
 	it('#createUUID()', () => {
@@ -43,20 +43,20 @@ describe('Titanium.Platform', function () {
 					try {
 						Ti.Android.rootActivity.removeEventListener('newintent', listener);
 						should(e.intent.data).be.eql(url);
-						finish();
 					} catch (err) {
-						finish(err);
+						return finish(err);
 					}
+					finish();
 				});
 			} else if (utilities.isIOS()) {
 				Ti.App.iOS.addEventListener('handleurl', function listener(e) {
 					try {
 						Ti.App.iOS.removeEventListener('handleurl', listener);
 						should(e.launchOptions.url).be.eql(url);
-						finish();
 					} catch (err) {
-						finish(err);
+						return finish(err);
 					}
+					finish();
 				});
 			} else {
 				finish(new Error('This test is not supported on this platform.'));
@@ -66,12 +66,12 @@ describe('Titanium.Platform', function () {
 		it('(url)', (finish) => {
 			const url = 'mocha://test1';
 			handleUrl(url, finish);
-			should(Ti.Platform.openURL).be.a.Function;
+			should(Ti.Platform.openURL).be.a.Function();
 			const wasOpened = Ti.Platform.openURL(url);
 			if (utilities.isIOS()) {
-				should(wasOpened).be.a.Boolean;
+				should(wasOpened).be.a.Boolean();
 			} else {
-				should(wasOpened).be.eql(true);
+				should(wasOpened).be.true();
 			}
 		});
 
@@ -83,26 +83,27 @@ describe('Titanium.Platform', function () {
 			handleUrl(url, (err) => {
 				wasUrlReceived = true;
 				if (err) {
-					finish(err);
-				} else if (wasCallbackInvoked) {
+					return finish(err);
+				}
+				if (wasCallbackInvoked) {
 					finish();
 				}
 			});
 			const wasOpened = Ti.Platform.openURL(url, (e) => {
 				try {
 					wasCallbackInvoked = true;
-					should(e.success).be.eql(true);
-					if (wasUrlReceived) {
-						finish();
-					}
+					should(e.success).be.true();
 				} catch (err) {
-					finish(err);
+					return finish(err);
+				}
+				if (wasUrlReceived) {
+					finish();
 				}
 			});
 			if (utilities.isIOS()) {
 				should(wasOpened).be.a.Boolean;
 			} else {
-				should(wasOpened).be.eql(true);
+				should(wasOpened).be.true();
 			}
 		});
 
@@ -114,8 +115,9 @@ describe('Titanium.Platform', function () {
 			handleUrl(url, (err) => {
 				wasUrlReceived = true;
 				if (err) {
-					finish(err);
-				} else if (wasCallbackInvoked) {
+					return finish(err);
+				}
+				if (wasCallbackInvoked) {
 					finish();
 				}
 			});
@@ -125,12 +127,12 @@ describe('Titanium.Platform', function () {
 			const wasOpened = Ti.Platform.openURL(url, options, (e) => {
 				try {
 					wasCallbackInvoked = true;
-					should(e.success).be.eql(true);
-					if (wasUrlReceived) {
-						finish();
-					}
+					should(e.success).be.true();
 				} catch (err) {
-					finish(err);
+					return finish(err);
+				}
+				if (wasUrlReceived) {
+					finish();
 				}
 			});
 			if (utilities.isIOS()) {
@@ -188,9 +190,9 @@ describe('Titanium.Platform', function () {
 		should(Ti.Platform.batteryMonitoring).be.a.Boolean();
 		// Note: Windows 10 Mobile doesn't support battery monitoring
 		if (utilities.isWindowsPhone() && !/^10\./.test(Ti.Platform.version)) {
-			should(Ti.Platform.batteryMonitoring).be.eql(true);
+			should(Ti.Platform.batteryMonitoring).be.true();
 		} else if (utilities.isWindowsDesktop()) {
-			should(Ti.Platform.batteryMonitoring).be.eql(false);
+			should(Ti.Platform.batteryMonitoring).be.false();
 		}
 	});
 

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -124,6 +124,18 @@ async function addTiAppProperties() {
 		content.push('\t\t\t<application>');
 		content.push('\t\t\t\t<meta-data android:name="com.google.android.geo.API_KEY" android:value="AIzaSyCN_aC6RMaynan8YzsO1HNHbhsr9ZADDlY"/>');
 		content.push('\t\t\t\t<uses-library android:name="org.apache.http.legacy" android:required="false" />');
+		content.push(`\t\t\t\t<activity android:name=".${PROJECT_NAME.charAt(0).toUpperCase() + PROJECT_NAME.slice(1)}Activity">`);
+		content.push('\t\t\t\t\t<intent-filter>');
+		content.push('\t\t\t\t\t\t<action android:name="android.intent.action.MAIN"/>');
+		content.push('\t\t\t\t\t\t<category android:name="android.intent.category.LAUNCHER"/>');
+		content.push('\t\t\t\t\t</intent-filter>');
+		content.push('\t\t\t\t\t<intent-filter>');
+		content.push(`\t\t\t\t\t\t<data android:scheme="${PROJECT_NAME}"/>`);
+		content.push('\t\t\t\t\t\t<action android:name="android.intent.action.VIEW"/>');
+		content.push('\t\t\t\t\t\t<category android:name="android.intent.category.DEFAULT"/>');
+		content.push('\t\t\t\t\t\t<category android:name="android.intent.category.BROWSABLE"/>');
+		content.push('\t\t\t\t\t</intent-filter>');
+		content.push('\t\t\t\t</activity>');
 		content.push('\t\t\t</application>');
 		content.push('\t\t\t<uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>');
 	};

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -124,7 +124,7 @@ async function addTiAppProperties() {
 		content.push('\t\t\t<application>');
 		content.push('\t\t\t\t<meta-data android:name="com.google.android.geo.API_KEY" android:value="AIzaSyCN_aC6RMaynan8YzsO1HNHbhsr9ZADDlY"/>');
 		content.push('\t\t\t\t<uses-library android:name="org.apache.http.legacy" android:required="false" />');
-		content.push(`\t\t\t\t<activity android:name=".${PROJECT_NAME.charAt(0).toUpperCase() + PROJECT_NAME.slice(1)}Activity">`);
+		content.push(`\t\t\t\t<activity android:name=".${PROJECT_NAME.charAt(0).toUpperCase() + PROJECT_NAME.slice(1).toLowerCase()}Activity">`);
 		content.push('\t\t\t\t\t<intent-filter>');
 		content.push('\t\t\t\t\t\t<action android:name="android.intent.action.MAIN"/>');
 		content.push('\t\t\t\t\t\t<category android:name="android.intent.category.LAUNCHER"/>');


### PR DESCRIPTION
**Summary:**
- Added 3 `openURL()` tests. Verifies it works by having app open itself
  * Verifies it works by having app open itself via "mocha://" custom URL scheme.
  * Tests optional arguments such as callback and options dictionary.
- Added `canOpenURL()` test for app's own custom URL scheme.

**Note:**
Do not merge this PR until the following Titanium SDK PRs have been merged...
- https://github.com/appcelerator/titanium_mobile/pull/11655
- https://github.com/appcelerator/titanium_mobile/pull/11668
